### PR TITLE
Update port and document env config

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,12 @@ pip install flask flask-cors
 # Server starten
 python server.py
 
-# Browser öffnen: http://localhost:5000
+# Browser öffnen: http://localhost:5001
+```
+
+Port ändern:
+```bash
+PORT=5002 python server.py
 ```
 
 ## 📁 **Dateien im Paket**
@@ -106,11 +111,11 @@ cp zeiterfassung_backup_2025-06-23.db zeiterfassung.db
 ```
 
 ### **Netzwerk-Zugriff (optional):**
-In `server.py` ändern:
-```python
-app.run(host='0.0.0.0', port=5000, debug=False)
+Server auf allen Netzwerkschnittstellen starten:
+```bash
+PORT=5001 python server.py
 ```
-Dann von anderen PCs erreichbar unter: `http://[IP-ADRESSE]:5000`
+Dann von anderen PCs erreichbar unter: `http://[IP-ADRESSE]:5001`
 
 ## 🛠 **Problemlösung**
 
@@ -119,8 +124,8 @@ Dann von anderen PCs erreichbar unter: `http://[IP-ADRESSE]:5000`
 - Bei Installation "Add to PATH" aktivieren
 
 ### **"Port bereits belegt"**
-- In `server.py` Port ändern: `port=5001`
-- In `app.js` API_BASE_URL anpassen: `http://localhost:5001/api`
+- Anderen Port per Umgebungsvariable setzen, z.B.: `PORT=5002 ./start.sh`
+- In `app.js` API_BASE_URL entsprechend anpassen: `http://localhost:5002/api`
 
 ### **"Keine Verbindung zum Server"**
 - Prüfen ob `server.py` läuft

--- a/server.py
+++ b/server.py
@@ -388,6 +388,7 @@ if __name__ == '__main__':
     
     # Server starten
     print("Starte Zeiterfassung Server...")
-    print("Öffne http://localhost:5001 in deinem Browser")
-    app.run(host='0.0.0.0', port=5001, debug=True)
+    port = int(os.environ.get("PORT", 5001))
+    print(f"Öffne http://localhost:{port} in deinem Browser")
+    app.run(host='0.0.0.0', port=port, debug=True)
 

--- a/start.bat
+++ b/start.bat
@@ -20,15 +20,18 @@ echo.
 REM Installiere Flask falls nicht vorhanden
 pip install flask flask-cors >nul 2>&1
 
+REM Port setzen (vorhandene PORT-Variable verwenden oder 5001)
+if not defined PORT set PORT=5001
+
 REM Starte den Server
-echo Server startet auf http://localhost:5000
+echo Server startet auf http://localhost:%PORT%
 echo.
 echo WICHTIG: Lassen Sie dieses Fenster offen!
 echo Zum Beenden druecken Sie Strg+C
 echo.
 echo Oeffne automatisch den Browser...
 timeout /t 2 >nul
-start http://localhost:5000
+start http://localhost:%PORT%
 
 python server.py
 

--- a/start.sh
+++ b/start.sh
@@ -21,8 +21,12 @@ echo
 # Installiere Flask falls nicht vorhanden
 pip3 install flask flask-cors > /dev/null 2>&1
 
+# Port setzen (übernimmt vorhandene PORT-Variable oder nutzt 5001)
+PORT=${PORT:-5001}
+export PORT
+
 # Starte den Server
-echo "Server startet auf http://localhost:5000"
+echo "Server startet auf http://localhost:$PORT"
 echo
 echo "WICHTIG: Lassen Sie dieses Terminal offen!"
 echo "Zum Beenden drücken Sie Strg+C"
@@ -32,9 +36,9 @@ sleep 2
 
 # Öffne Browser (funktioniert auf macOS und Linux)
 if command -v open &> /dev/null; then
-    open http://localhost:5000
+    open http://localhost:$PORT
 elif command -v xdg-open &> /dev/null; then
-    xdg-open http://localhost:5000
+    xdg-open http://localhost:$PORT
 fi
 
 python3 server.py


### PR DESCRIPTION
## Summary
- update `server.py` to read port from `PORT` environment variable
- make `start.sh` and `start.bat` default to port 5001
- open browser with selected port in start scripts
- reference port 5001 in documentation
- document how to override port via environment variable

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_b_685a9134e6348323b98d2fcb78fbb167