### PR TITLE
Optional debug via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ Port ändern:
 PORT=5002 python server.py
 ```
 
+Debug-Modus aktivieren:
+```bash
+FLASK_DEBUG=1 python server.py
+```
+
 ## 📁 **Dateien im Paket**
 
 ```

--- a/server.py
+++ b/server.py
@@ -390,5 +390,6 @@ if __name__ == '__main__':
     print("Starte Zeiterfassung Server...")
     port = int(os.environ.get("PORT", 5001))
     print(f"Öffne http://localhost:{port} in deinem Browser")
-    app.run(host='0.0.0.0', port=port, debug=True)
+    debug_mode = os.environ.get("FLASK_DEBUG", "0").lower() in ("1", "true")
+    app.run(host='0.0.0.0', port=port, debug=debug_mode)
 


### PR DESCRIPTION
## Summary
- allow starting server in debug mode only when `FLASK_DEBUG` is set
- document `FLASK_DEBUG` usage in the README

## Testing
- `python3 -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_b_685a9228f0888323b3a968ff26c7e748