### PR TITLE
Add employee management view

### DIFF
--- a/app.js
+++ b/app.js
@@ -55,6 +55,8 @@ async function loadEmployees() {
                 select.appendChild(option);
             }
         });
+
+        renderEmployeeList();
     } catch (error) {
         console.error('Error loading employees:', error);
         showError('Fehler beim Laden der Mitarbeiter: ' + error.message);
@@ -389,4 +391,66 @@ document.getElementById('timeModal').addEventListener('click', function(e) {
         closeModal();
     }
 });
+
+// Close employee modal when clicking outside
+document.getElementById('employeeModal').addEventListener('click', function(e) {
+    if (e.target === this) {
+        closeEmployeeModal();
+    }
+});
+
+// Render employee table
+function renderEmployeeList() {
+    const tbody = document.getElementById('employeeTableBody');
+    tbody.innerHTML = '';
+
+    employees.forEach(emp => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${emp.name}</td>
+            <td>${emp.has_commission ? 'Ja' : 'Nein'}</td>
+            <td>${emp.is_active ? 'Nein' : 'Ja'}</td>
+            <td>${new Date(emp.created_at).toLocaleDateString('de-DE')}</td>
+        `;
+        tbody.appendChild(tr);
+    });
+}
+
+function openEmployeeModal() {
+    document.getElementById('employeeModal').classList.add('show');
+}
+
+function closeEmployeeModal() {
+    document.getElementById('employeeModal').classList.remove('show');
+    document.getElementById('empName').value = '';
+    document.getElementById('empHours').value = '';
+    document.getElementById('empCommission').checked = false;
+}
+
+async function saveEmployee() {
+    const name = document.getElementById('empName').value.trim();
+    const hours = parseInt(document.getElementById('empHours').value) || 0;
+    const commission = document.getElementById('empCommission').checked;
+
+    if (!name || hours <= 0) {
+        alert('Bitte Name und Vertragsstunden angeben.');
+        return;
+    }
+
+    try {
+        await apiCall('/employees', {
+            method: 'POST',
+            body: JSON.stringify({
+                name: name,
+                contract_hours: hours,
+                has_commission: commission
+            })
+        });
+        closeEmployeeModal();
+        await loadEmployees();
+    } catch (error) {
+        console.error('Error saving employee:', error);
+        alert('Fehler beim Speichern des Mitarbeiters: ' + error.message);
+    }
+}
 

--- a/index.html
+++ b/index.html
@@ -470,6 +470,22 @@
             color: #6c757d;
         }
 
+        /* Employee table */
+        .employee-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 20px;
+        }
+        .employee-table th,
+        .employee-table td {
+            padding: 10px;
+            border: 1px solid #dee2e6;
+            text-align: left;
+        }
+        .employee-table th {
+            background: #f8f9fa;
+        }
+
         /* Responsive */
         @media (max-width: 768px) {
             .container {
@@ -579,7 +595,18 @@
                 <!-- Weitere Sections... -->
                 <div id="employees" class="section">
                     <h2>Mitarbeiter-Verwaltung</h2>
-                    <p>Hier können Mitarbeiter verwaltet werden.</p>
+                    <button class="btn btn-primary" onclick="openEmployeeModal()" style="margin: 10px 0;">Neuer Mitarbeiter</button>
+                    <table class="employee-table">
+                        <thead>
+                            <tr>
+                                <th>Name</th>
+                                <th>Provision</th>
+                                <th>Ausgeschieden</th>
+                                <th>Beginn</th>
+                            </tr>
+                        </thead>
+                        <tbody id="employeeTableBody"></tbody>
+                    </table>
                 </div>
 
                 <div id="reports" class="section">
@@ -659,6 +686,33 @@
             <div class="modal-actions">
                 <button class="btn btn-secondary" onclick="closeModal()">Abbrechen</button>
                 <button class="btn btn-primary" onclick="saveEntry()">Speichern</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Modal für neuen Mitarbeiter -->
+    <div id="employeeModal" class="modal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Neuer Mitarbeiter</h3>
+                <button class="close-btn" onclick="closeEmployeeModal()">&times;</button>
+            </div>
+            <div class="form-grid">
+                <div class="form-group">
+                    <label>Name:</label>
+                    <input type="text" id="empName">
+                </div>
+                <div class="form-group">
+                    <label>Vertragsstunden/Woche:</label>
+                    <input type="number" id="empHours" min="1">
+                </div>
+                <div class="form-group">
+                    <label><input type="checkbox" id="empCommission"> Berechtigt für Provision</label>
+                </div>
+            </div>
+            <div class="modal-actions">
+                <button class="btn btn-secondary" onclick="closeEmployeeModal()">Abbrechen</button>
+                <button class="btn btn-primary" onclick="saveEmployee()">Speichern</button>
             </div>
         </div>
     </div>

--- a/server.py
+++ b/server.py
@@ -102,7 +102,7 @@ def health_check():
 def get_employees():
     """Alle Mitarbeiter abrufen"""
     conn = get_db_connection()
-    employees = conn.execute('SELECT * FROM employees WHERE is_active = 1 ORDER BY name').fetchall()
+    employees = conn.execute('SELECT * FROM employees ORDER BY name').fetchall()
     conn.close()
     
     return jsonify([dict(row) for row in employees])


### PR DESCRIPTION
## Summary
- display employees in a new table with add button
- allow adding new employees via modal dialog
- expose all employees from API

## Testing
- `python3 -m py_compile server.py`

------
https://chatgpt.com/codex/tasks/task_b_685a9466d06c832391ad32559fc38913