### PR TITLE
Add termination date and validate time entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,14 @@ zeiterfassung-sqlite/
 - **Duftreisen:** Bis 18h / Ab 18h (mehrfach möglich)
 - **Provision:** Wird angezeigt (später automatisch berechnet)
 - **Notizen:** Zusätzliche Informationen
+- **Beschäftigungszeitraum:** Start- und Enddatum des Mitarbeiters erfassen
 
 ### **4. Besonderheiten**
 - **Samstag ist Arbeitstag** (Einzelhandel)
 - **Duftreisen unabhängig** von Arbeitszeit
 - **Urlaub/Krank** macht andere Einträge irrelevant
 - **Automatische Speicherung** in SQLite-Datenbank
+- **Beschäftigungszeitraum** eintragbar (Start- und Enddatum)
 
 ## 🔧 **Erweiterte Funktionen**
 

--- a/index.html
+++ b/index.html
@@ -603,6 +603,7 @@
                                 <th>Provision</th>
                                 <th>Ausgeschieden</th>
                                 <th>Beginn</th>
+                                <th>Ende</th>
                             </tr>
                         </thead>
                         <tbody id="employeeTableBody"></tbody>
@@ -694,7 +695,7 @@
     <div id="employeeModal" class="modal">
         <div class="modal-content">
             <div class="modal-header">
-                <h3 class="modal-title">Neuer Mitarbeiter</h3>
+                <h3 class="modal-title" id="employeeModalTitle">Neuer Mitarbeiter</h3>
                 <button class="close-btn" onclick="closeEmployeeModal()">&times;</button>
             </div>
             <div class="form-grid">
@@ -708,6 +709,17 @@
                 </div>
                 <div class="form-group">
                     <label><input type="checkbox" id="empCommission"> Berechtigt für Provision</label>
+                </div>
+                <div class="form-group">
+                    <label>Startdatum:</label>
+                    <input type="date" id="empStart">
+                </div>
+                <div class="form-group">
+                    <label>Enddatum:</label>
+                    <input type="date" id="empEnd">
+                </div>
+                <div class="form-group">
+                    <label><input type="checkbox" id="empActive" checked> Aktiv</label>
                 </div>
             </div>
             <div class="modal-actions">


### PR DESCRIPTION
## Summary
- support start and end dates for employees
- allow editing employees with start and end dates
- show employment dates in the employee list
- reject time entries outside of employment period

## Testing
- `python3 -m py_compile server.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_685a9877294483239df4b4a5303e31e6