### PR TITLE
Set current date as default month/year

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,13 +3,15 @@ const API_BASE_URL = 'http://localhost:5001/api';
 
 // Global variables
 let currentEmployee = null;
-let currentMonth = 5; // Juni (0-based)
-let currentYear = 2025;
+// Use today's date as initial selection
+const today = new Date();
+let currentMonth = today.getMonth();
+let currentYear = today.getFullYear();
 let timeEntries = [];
 let employees = [];
 let revenueEntries = [];
-let currentRevenueMonth = 5;
-let currentRevenueYear = 2025;
+let currentRevenueMonth = currentMonth;
+let currentRevenueYear = currentYear;
 
 // Format date as YYYY-MM-DD in local time
 function formatDate(date) {
@@ -22,6 +24,12 @@ document.addEventListener('DOMContentLoaded', async function() {
     console.log('App initializing...');
     await loadEmployees();
     loadDashboard();
+
+    // Set dropdowns to current month and year
+    document.getElementById('monthSelect').value = String(currentMonth);
+    document.getElementById('yearSelect').value = String(currentYear);
+    document.getElementById('revMonthSelect').value = String(currentMonth);
+    document.getElementById('revYearSelect').value = String(currentYear);
 });
 
 // API Functions

--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
                                 <option value="2">März</option>
                                 <option value="3">April</option>
                                 <option value="4">Mai</option>
-                                <option value="5" selected>Juni</option>
+                                <option value="5">Juni</option>
                                 <option value="6">Juli</option>
                                 <option value="7">August</option>
                                 <option value="8">September</option>
@@ -580,7 +580,7 @@
                             <select id="yearSelect">
                                 <option value="2023">2023</option>
                                 <option value="2024">2024</option>
-                                <option value="2025" selected>2025</option>
+                                <option value="2025">2025</option>
                                 <option value="2026">2026</option>
                             </select>
                         </div>
@@ -626,7 +626,7 @@
                                 <option value="2">März</option>
                                 <option value="3">April</option>
                                 <option value="4">Mai</option>
-                                <option value="5" selected>Juni</option>
+                                <option value="5">Juni</option>
                                 <option value="6">Juli</option>
                                 <option value="7">August</option>
                                 <option value="8">September</option>
@@ -640,7 +640,7 @@
                             <select id="revYearSelect">
                                 <option value="2023">2023</option>
                                 <option value="2024">2024</option>
-                                <option value="2025" selected>2025</option>
+                                <option value="2025">2025</option>
                                 <option value="2026">2026</option>
                             </select>
                         </div>


### PR DESCRIPTION
## Summary
- use today's date when initializing `currentMonth` and `currentYear`
- set dropdowns to the current month and year after page load
- remove hard‑coded selected attributes from month/year selects

## Testing
- `python3 -m py_compile server.py`
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_b_685aa5d9efb083238cedaffeb75132c9