### PR TITLE
Remove dummy employee seed data

### DIFF
--- a/server.py
+++ b/server.py
@@ -147,25 +147,6 @@ def init_database():
                 "UPDATE commission_thresholds SET valid_from = '1970-01-01' WHERE valid_from IS NULL"
             )
     
-    # Beispieldaten einfügen falls Tabelle leer
-    cursor.execute('SELECT COUNT(*) FROM employees')
-    if cursor.fetchone()[0] == 0:
-        today = date.today().isoformat()
-        employees = [
-            ("Alina W.", 20, 0, 1, today),
-            ("Valeria Z.", 25, 1, 1, today),
-            ("Eva C.", 30, 1, 1, today),
-            ("Hannah S.", 20, 0, 1, today),
-            ("Hans K.", 40, 1, 1, today),
-            ("Lena K.", 25, 1, 1, today),
-            ("Lorena M.", 30, 1, 1, today),
-            ("Lilo Ming K.", 20, 0, 1, today)
-        ]
-        cursor.executemany(
-            'INSERT INTO employees (name, contract_hours, has_commission, is_active, start_date) VALUES (?, ?, ?, ?, ?)',
-            employees
-        )
-    
     conn.commit()
     conn.close()
     print("Datenbank initialisiert!")

--- a/test_commission_thresholds.py
+++ b/test_commission_thresholds.py
@@ -31,6 +31,17 @@ class CommissionThresholdsTestCase(unittest.TestCase):
         cursor.execute('DELETE FROM commission_thresholds')
         cursor.execute('DELETE FROM time_entries')
         cursor.execute('DELETE FROM revenue')
+        cursor.execute('DELETE FROM employees')
+
+        cursor.execute(
+            '''
+                INSERT INTO employees (
+                    name, contract_hours, has_commission, is_active, start_date
+                ) VALUES (?, ?, ?, ?, ?)
+            ''',
+            ('Test Employee', 40, 1, 1, '2023-01-01'),
+        )
+        employee_id = cursor.lastrowid
 
         cursor.execute(
             '''
@@ -54,7 +65,7 @@ class CommissionThresholdsTestCase(unittest.TestCase):
                     commission, duftreise_bis_18, duftreise_ab_18, notes
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''',
-            (2, '2023-06-05', 'work', '09:00', '17:00', 60, 0, 0, 0, ''),
+            (employee_id, '2023-06-05', 'work', '09:00', '17:00', 60, 0, 0, 0, ''),
         )
         cursor.execute(
             'INSERT INTO revenue (date, amount, notes) VALUES (?, ?, ?)',
@@ -68,7 +79,7 @@ class CommissionThresholdsTestCase(unittest.TestCase):
                     commission, duftreise_bis_18, duftreise_ab_18, notes
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             ''',
-            (2, '2024-06-03', 'work', '09:00', '17:00', 60, 0, 0, 0, ''),
+            (employee_id, '2024-06-03', 'work', '09:00', '17:00', 60, 0, 0, 0, ''),
         )
         cursor.execute(
             'INSERT INTO revenue (date, amount, notes) VALUES (?, ?, ?)',


### PR DESCRIPTION
## Summary
- remove automatic insertion of placeholder employees during database initialization
- adjust commission threshold test to create its own employee records

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d38da9b6748323b5b0b7305aefec89