### PR TITLE
Make frontend API base URL relative to current host

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 // API Configuration
-const API_BASE_URL = 'http://localhost:5001/api';
+const { protocol, host } = window.location;
+const API_BASE_URL = `${protocol}//${host}/api`;
 
 // Global variables
 let currentEmployee = null;


### PR DESCRIPTION
## Summary
- build the frontend API base URL from window.location so it automatically matches the current host

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dad5e9005883239f40a074209d3fb0