### PR TITLE
Automatically refresh calendar on employee selection change

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,13 @@ function formatDate(date) {
 document.addEventListener('DOMContentLoaded', async function() {
     console.log('App initializing...');
     await loadEmployees();
+    const employeeSelect = document.getElementById('employeeSelect');
+    employeeSelect.addEventListener('change', async (e) => {
+        if (!e.target.value) {
+            return;
+        }
+        await loadCalendar();
+    });
     loadDashboard();
 
     await loadCommissionSettings();


### PR DESCRIPTION
## Summary
- add a change listener to the employee selector to refresh the calendar on selection changes
- prevent unnecessary calendar loads when no employee is chosen

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dbba7891b48323836e301d5b8499bd