### PR TITLE
Split duftreise totals in month summary

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,10 +253,14 @@ function renderMonthSummary() {
         return sum;
     }, 0);
     
-    const totalDuftreisen = timeEntries.reduce((sum, entry) => {
-        const bis18 = Number(entry.duftreise_bis_18 ?? 0);
-        const ab18 = Number(entry.duftreise_ab_18 ?? 0);
-        return sum + (Number.isFinite(bis18) ? bis18 : 0) + (Number.isFinite(ab18) ? ab18 : 0);
+    const totalDuftreiseBis18 = timeEntries.reduce((sum, entry) => {
+        const value = Number(entry.duftreise_bis_18 ?? 0);
+        return sum + (Number.isFinite(value) ? value : 0);
+    }, 0);
+
+    const totalDuftreiseAb18 = timeEntries.reduce((sum, entry) => {
+        const value = Number(entry.duftreise_ab_18 ?? 0);
+        return sum + (Number.isFinite(value) ? value : 0);
     }, 0);
 
     const totalProvision = timeEntries.reduce((sum, entry) => {
@@ -287,8 +291,12 @@ function renderMonthSummary() {
                 <div class="summary-label">Krankheitstage</div>
             </div>
             <div class="summary-item">
-                <div class="summary-value">${totalDuftreisen}</div>
-                <div class="summary-label">Duftreisen gesamt</div>
+                <div class="summary-value">${totalDuftreiseBis18}</div>
+                <div class="summary-label">Duftreisen vor 18 Uhr</div>
+            </div>
+            <div class="summary-item">
+                <div class="summary-value">${totalDuftreiseAb18}</div>
+                <div class="summary-label">Duftreisen nach 18 Uhr</div>
             </div>
             <div class="summary-item">
                 <div class="summary-value">${safeTotalProvision.toFixed(2)}€</div>

--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
 
         .summary-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
             gap: 20px;
         }
 


### PR DESCRIPTION
## Summary
- separate Duftreise aggregations in the monthly summary into before/after 18:00 buckets
- surface both totals in the month summary UI and tighten the grid column width for better fit

## Testing
- Manual test in browser: added time entry with Duftreise values for both slots and confirmed the monthly summary shows both totals

------
https://chatgpt.com/codex/tasks/task_b_68dbbc6dde008323a5e560de7b1b6714