### PR TITLE
Format time modal title with localized weekday

### DIFF
--- a/app.js
+++ b/app.js
@@ -336,7 +336,17 @@ function openTimeModal(dateStr) {
     const title = document.getElementById('modalTitle');
     const date = new Date(dateStr);
     
-    title.textContent = `Zeiterfassung - ${date.toLocaleDateString('de-DE')}`;
+    const formattedDate = date.toLocaleDateString('de-DE', {
+        weekday: 'long',
+        day: '2-digit',
+        month: '2-digit',
+        year: 'numeric'
+    });
+    const capitalizedDate = formattedDate
+        ? formattedDate.charAt(0).toUpperCase() + formattedDate.slice(1)
+        : '';
+
+    title.textContent = `Zeiterfassung – ${capitalizedDate}`;
     
     // Find existing entry
     const entry = timeEntries.find(e => e.date === dateStr);


### PR DESCRIPTION
## Summary
- format the time modal title with a German localized weekday and date
- ensure the formatted date is capitalized and displayed with an en dash

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68dbc04009688323ad2fff8a62d652b0