### PR TITLE
Add duftreise time split to PDF overview

### DIFF
--- a/server.py
+++ b/server.py
@@ -914,16 +914,21 @@ def _render_reports_overview_pdf(prepared_overview, month_name, generated_at):
             styles['EmployeeName'],
         )
 
-        duftreise_total = (summary.get('total_duftreise_bis_18') or 0) + (
-            summary.get('total_duftreise_ab_18') or 0
-        )
-
         metrics_config = [
             ('Gesamtstunden', summary.get('total_hours'), ''),
             ('Arbeitstage', summary.get('work_days'), ''),
             ('Urlaubstage', summary.get('vacation_days'), ''),
             ('Krankheitstage', summary.get('sick_days'), ''),
-            ('Duftreisen gesamt', duftreise_total, ''),
+            (
+                'Duftreisen vor 18 Uhr',
+                summary.get('total_duftreise_bis_18'),
+                '',
+            ),
+            (
+                'Duftreisen nach 18 Uhr',
+                summary.get('total_duftreise_ab_18'),
+                '',
+            ),
             ('Provision gesamt', summary.get('total_commission'), ' €'),
         ]
 


### PR DESCRIPTION
## Summary
- show separate Duftreisen counts before and after 18:00 in the monthly PDF overview

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e43f52b7348323b58f741a0e0ebff6