### PR TITLE
Berücksichtige alle Mitarbeitenden für Provisionsschwelle

### DIFF
--- a/test_commission_thresholds.py
+++ b/test_commission_thresholds.py
@@ -107,6 +107,89 @@ class CommissionThresholdsTestCase(unittest.TestCase):
         self.assertEqual(commission_old, 15.0)
         self.assertEqual(commission_new, 0)
 
+    def test_threshold_counts_all_employees(self):
+        conn = server.get_db_connection()
+        cursor = conn.cursor()
+
+        cursor.execute('DELETE FROM commission_thresholds')
+        cursor.execute('DELETE FROM time_entries')
+        cursor.execute('DELETE FROM revenue')
+        cursor.execute('DELETE FROM employees')
+
+        cursor.execute(
+            '''
+                INSERT INTO employees (
+                    name, contract_hours, has_commission, is_active, start_date
+                ) VALUES (?, ?, ?, ?, ?)
+            ''',
+            ('Eligible Employee', 40, 1, 1, '2023-01-01'),
+        )
+        eligible_id = cursor.lastrowid
+
+        cursor.execute(
+            '''
+                INSERT INTO employees (
+                    name, contract_hours, has_commission, is_active, start_date
+                ) VALUES (?, ?, ?, ?, ?)
+            ''',
+            ('Ineligible Employee', 40, 0, 1, '2023-01-01'),
+        )
+        ineligible_id = cursor.lastrowid
+
+        cursor.execute(
+            '''
+                INSERT INTO commission_thresholds (weekday, employee_count, threshold, valid_from)
+                VALUES (?, ?, ?, ?)
+            ''',
+            (0, 1, 100, '2023-01-01'),
+        )
+        cursor.execute(
+            '''
+                INSERT INTO commission_thresholds (weekday, employee_count, threshold, valid_from)
+                VALUES (?, ?, ?, ?)
+            ''',
+            (0, 2, 200, '2023-01-01'),
+        )
+
+        cursor.execute(
+            '''
+                INSERT INTO time_entries (
+                    employee_id, date, entry_type, start_time, end_time, pause_minutes,
+                    commission, duftreise_bis_18, duftreise_ab_18, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ''',
+            (eligible_id, '2024-06-03', 'work', '09:00', '17:00', 60, 0, 0, 0, ''),
+        )
+        cursor.execute(
+            '''
+                INSERT INTO time_entries (
+                    employee_id, date, entry_type, start_time, end_time, pause_minutes,
+                    commission, duftreise_bis_18, duftreise_ab_18, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ''',
+            (ineligible_id, '2024-06-03', 'work', '09:00', '17:00', 60, 0, 0, 0, ''),
+        )
+
+        cursor.execute(
+            'INSERT INTO revenue (date, amount, notes) VALUES (?, ?, ?)',
+            ('2024-06-03', 150, ''),
+        )
+
+        conn.commit()
+        conn.close()
+
+        server.compute_commission_for_date('2024-06-03')
+
+        conn = server.get_db_connection()
+        cursor = conn.cursor()
+        commission = cursor.execute(
+            'SELECT commission FROM time_entries WHERE employee_id = ? AND date = ?',
+            (eligible_id, '2024-06-03'),
+        ).fetchone()[0]
+        conn.close()
+
+        self.assertEqual(commission, 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- berücksichtige bei der Auswahl des Provisionsschwellwerts alle Mitarbeitenden mit Arbeitszeiteintrag
- verteile die Provision weiterhin nur an berechtigte Mitarbeitende und ergänze einen Regressionstest

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e4466c50c883239fa56da7d6ba7947