### PR TITLE
Add detailed PDF export option for report overview

### DIFF
--- a/app.js
+++ b/app.js
@@ -69,6 +69,11 @@ document.addEventListener('DOMContentLoaded', async function() {
     if (reportsPdfExportButton) {
         reportsPdfExportButton.addEventListener('click', exportReportsOverviewPdf);
     }
+
+    const reportsPdfDetailedExportButton = document.getElementById('reportsPdfDetailedExportButton');
+    if (reportsPdfDetailedExportButton) {
+        reportsPdfDetailedExportButton.addEventListener('click', exportReportsOverviewPdfDetailed);
+    }
 });
 
 // API Functions
@@ -357,6 +362,48 @@ async function exportReportsOverviewPdf() {
     const monthNumber = String(month + 1).padStart(2, '0');
     const fileName = `auswertungen_${year}_${monthNumber}.pdf`;
     const exportUrl = `${API_BASE_URL}/reports/overview/${year}/${month + 1}/export/pdf`;
+
+    try {
+        const response = await fetch(exportUrl);
+
+        if (!response.ok) {
+            throw new Error(`Export fehlgeschlagen: ${response.status}`);
+        }
+
+        const blob = await response.blob();
+        const url = URL.createObjectURL(blob);
+
+        const link = document.createElement('a');
+        link.href = url;
+        link.download = fileName;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+    } catch (error) {
+        console.error('PDF export error:', error);
+        alert(`Fehler beim PDF-Export der Auswertungen: ${error.message}`);
+    }
+}
+
+async function exportReportsOverviewPdfDetailed() {
+    const monthSelect = document.getElementById('reportsMonthSelect');
+    const yearSelect = document.getElementById('reportsYearSelect');
+
+    const month = monthSelect ? parseInt(monthSelect.value, 10) : currentReportsMonth;
+    const year = yearSelect ? parseInt(yearSelect.value, 10) : currentReportsYear;
+
+    if (!Number.isFinite(month) || !Number.isFinite(year)) {
+        alert('Bitte wählen Sie zuerst einen gültigen Monat und ein Jahr aus.');
+        return;
+    }
+
+    currentReportsMonth = month;
+    currentReportsYear = year;
+
+    const monthNumber = String(month + 1).padStart(2, '0');
+    const fileName = `auswertungen_${year}_${monthNumber}_detailliert.pdf`;
+    const exportUrl = `${API_BASE_URL}/reports/overview/${year}/${month + 1}/export/pdf/detailed`;
 
     try {
         const response = await fetch(exportUrl);

--- a/index.html
+++ b/index.html
@@ -691,6 +691,7 @@
                         <button class="btn btn-primary" id="reportsRefreshButton">Anzeigen</button>
                         <button class="btn btn-secondary" id="reportsExportButton">CSV Export</button>
                         <button class="btn btn-secondary" id="reportsPdfExportButton">PDF Export</button>
+                        <button class="btn btn-secondary" id="reportsPdfDetailedExportButton">PDF Export Detailliert</button>
                     </div>
                     <div id="reportsOverviewContainer">
                         <div class="loading">Bitte wählen Sie einen Zeitraum aus.</div>


### PR DESCRIPTION
## Summary
- add a dedicated "PDF Export Detailliert" button to the reports view
- extend the PDF exporter to optionally include per-day details per employee
- expose a new API endpoint and client download flow for the detailed PDF

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68e44bd48ee083238561606d9ff8443e