### PR TITLE
Count commission thresholds using only commission-eligible employees

### DIFF
--- a/server.py
+++ b/server.py
@@ -333,12 +333,12 @@ def compute_commission_for_date(date_str):
     emp_hours = {}
     entry_ids = {}
     ineligible_entry_ids = []
-    all_employee_ids = set()
+    commission_employee_ids = set()
     for row in entries:
         hours = calculate_work_hours(row['start_time'], row['end_time'], row['pause_minutes'])
-        all_employee_ids.add(row['employee_id'])
 
         if row['has_commission']:
+            commission_employee_ids.add(row['employee_id'])
             emp_hours.setdefault(row['employee_id'], 0)
             emp_hours[row['employee_id']] += hours
             entry_ids[row['employee_id']] = row['id']
@@ -353,7 +353,7 @@ def compute_commission_for_date(date_str):
 
     emp_hours = eligible_hours
 
-    employee_count = len(all_employee_ids)
+    employee_count = len(commission_employee_ids)
 
     weekday = datetime.strptime(date_str, '%Y-%m-%d').weekday()
     th = cursor.execute(
@@ -1574,4 +1574,3 @@ if __name__ == '__main__':
     print(f"Öffne http://localhost:{port} in deinem Browser")
     debug_mode = os.environ.get("FLASK_DEBUG", "0").lower() in ("1", "true")
     app.run(host='0.0.0.0', port=port, debug=debug_mode)
-


### PR DESCRIPTION
### Motivation

- Ensure daily commission threshold logic only considers employees who are eligible to receive commission (`has_commission`).
- Prevent ineligible employees from affecting the threshold lookup and commission distribution.

### Description

- Replace the previous all-employee counting with a `commission_employee_ids` set that only includes rows where `has_commission` is true in `compute_commission_for_date` in `server.py`.
- Use `employee_count = len(commission_employee_ids)` when querying `commission_thresholds` for the applicable threshold.
- Update the test `test_threshold_counts_all_employees` to `test_threshold_counts_only_commission_eligible_employees` and add pre-work entries so an eligible employee can reach the hourly requirement, asserting they receive commission as expected.
- Modified files: `server.py` and `test_commission_thresholds.py`.

### Testing

- Ran the unit test suite with `python test_commission_thresholds.py`.
- All tests completed successfully (`Ran 4 tests` and `OK`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_694c0192d16c83239ff9499c57a7ea49)